### PR TITLE
Add note about Travis CI to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ $ npm install tape-run -g # for cli
 $ npm install tape-run    # for api
 ```
 
+## Using with Travis CI
+
+When using `tape-run` with [Travis CI](https://travis-ci.org) you need to pass `phantom` as the `--browser` option. Travis CI does not have Electron installed.
+
+```bash
+browserify test/*.js | tape-run --browser phantom
+```
+
 ## License
 
 (MIT)


### PR DESCRIPTION
I just spent awhile trying to figure out why several tests weren't working on Travis CI when I realized I needed to pass the `--browser phantom` option. Adding a note in the readme might save someone else some time.