### PR TITLE
Use tarball url for tap-finished dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "browser-run": "^3.0.2",
     "optimist": "~0.6.1",
-    "tap-finished": "github:juliangruber/tap-finished#throw",
+    "tap-finished": "https://github.com/juliangruber/tap-finished/tarball/throw",
     "through": "~2.3.4",
     "throughout": "0.0.0"
   },


### PR DESCRIPTION
This should fix npm installs on Travis when juliangruber/tap-finished is a dependency

```
npm ERR! git clone git@github.com:github:juliangruber/tap-finished Cloning into bare repository '/home/travis/.npm/_git-remotes/git-github-com-github-juliangruber-tap-finished-f88aaa4e'...
npm ERR! git clone git@github.com:github:juliangruber/tap-finished Permission denied (publickey).
npm ERR! git clone git@github.com:github:juliangruber/tap-finished fatal: Could not read from remote repository.
npm ERR! git clone git@github.com:github:juliangruber/tap-finished 
npm ERR! git clone git@github.com:github:juliangruber/tap-finished Please make sure you have the correct access rights
npm ERR! git clone git@github.com:github:juliangruber/tap-finished and the repository exists.
```