### PR TITLE
Added browserOptions CLI argument support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,17 @@ ok 1 true
 Increase this value if tests finish without all tests being run.
 * `port (Number)`: If you specify a port it will wait for you to open a browser
 on `http://localhost:<port>` and tests will be run there.
-* `browser (String)`: Browser to use. Defaults to `electron`. Available if installed:
+* `browser (String)`: Browser to use. Defaults to `electron`. Usage `--browser=chrome`. Available if installed:
   * `chrome`
   * `firefox`
   * `ie`
   * `phantom`
   * `safari`
-* `browserOptions (Object)`: Browser options, for supported browsers (currently [electron only](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions)).
+* `browser (Object)`: Object with browser.name and browser.options fields:
+  * `browser.name (String)`: same as `browser (String)`. Usage `--browser.name=chrome`.
+  * `browser.options (Object)`: Browser options, for supported browsers (currently [electron only](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions)). Usage `--browser.name=electron --browser.options.width=800 --browser.options.height=500 --browser.options.webPreferences.webSecurity=false`
+
+ 
 
 The **CLI** takes the same arguments, plus `--render` (see blow):
 
@@ -104,8 +108,14 @@ browserify [opts] [files] | tape-run [opts]
 Options:
   --wait     Timeout for tap-finished                                                                                
   --port     Wait to be opened by a browser on that port                                                             
-  --browser  Browser to use. Always available: electron. Available if installed: chrome, firefox, ie, phantom, safari  [default: "electron"]
-  --browserOptions  Browser options, for supported browsers (currently electron only). Build options object using dot notation, like --browserOptions.width=800 --browserOptions.height=500 --browserOptions.webPreferences.webSecurity=false
+  --browser       [Object|String]. Object with browser.name and browser.options fields. Or string to pass browser.name only.
+    Always available: electron.
+    Options available: electron only.
+    Available if installed: chrome, firefox, ie, phantom, safari
+    Usage:
+      --browser=chrome - set browser name with no options passed.
+      --browser.name=electron --browser.options.width=800 --browser.options.height=500 --browser.options.webPreferences.webSecurity=false - set browser and specify browser options.
+      
   --render   Command to pipe tap output to for custom rendering
   --help     Print usage instructions                                                                                
 ```

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ on `http://localhost:<port>` and tests will be run there.
   * `ie`
   * `phantom`
   * `safari`
+* `browserOptions (Object)`: Browser options, for supported browsers (currently [electron only](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions)).
 
 The **CLI** takes the same arguments, plus `--render` (see blow):
 
@@ -104,9 +105,9 @@ Options:
   --wait     Timeout for tap-finished                                                                                
   --port     Wait to be opened by a browser on that port                                                             
   --browser  Browser to use. Always available: electron. Available if installed: chrome, firefox, ie, phantom, safari  [default: "electron"]
+  --browserOptions  Browser options, for supported browsers (currently electron only). Build options object using dot notation, like --browserOptions.width=800 --browserOptions.height=500 --browserOptions.webPreferences.webSecurity=false
   --render   Command to pipe tap output to for custom rendering
   --help     Print usage instructions                                                                                
-
 ```
 
 ## Custom Rendering

--- a/bin/run.js
+++ b/bin/run.js
@@ -13,14 +13,15 @@ var argv = optimist
   .describe('port', 'Wait to be opened by a browser on that port')
   .alias('p', 'port')
 
-  .describe('browser', 'Browser to use. ' +
-      'Always available: electron. ' +
-      'Available if installed: chrome, firefox, ie, phantom, safari')
+  .describe('browser', '[Object|String]. Object with browser.name and browser.options fields. Or string to pass browser.name only.' +
+      '\n\tAlways available: electron. ' +
+      '\n\tOptions available: electron only. ' +
+      '\n\tAvailable if installed: chrome, firefox, ie, phantom, safari' +
+      '\n\tUsage: '+
+      '\n\t\t--browser=chrome - set browser name with no options passed.' +
+      '\n\t\t--browser.name=electron --browser.options.width=800 --browser.options.height=500 --browser.options.webPreferences.webSecurity=false - set browser and specify browser options.\n')
   .alias('b', 'browser')
-  .default('browser', 'electron')
-
-  .describe('browserOptions', 'Browser options, for supported browsers (currently electron only). ' +
-            'Build options object using dot notation, like --browserOptions.width=800 --browserOptions.height=500 --browserOptions.webPreferences.webSecurity=false')
+  .default('browser.name', 'electron')
 
   .describe('render', 'Command to pipe tap output to for custom rendering')
   .alias('r', 'render')
@@ -32,6 +33,13 @@ var argv = optimist
 
 if (argv.help) {
   return optimist.showHelp();
+}
+
+if (typeof argv.browser == 'string') {
+  argv.browser = argv.b = {
+    name: argv.browser,
+    options: {}
+  };
 }
 
 var runner = run(argv);

--- a/bin/run.js
+++ b/bin/run.js
@@ -19,6 +19,9 @@ var argv = optimist
   .alias('b', 'browser')
   .default('browser', 'electron')
 
+  .describe('browserOptions', 'Browser options, for supported browsers (currently electron only). ' +
+            'Build options object using dot notation, like --browserOptions.width=800 --browserOptions.height=500 --browserOptions.webPreferences.webSecurity=false')
+
   .describe('render', 'Command to pipe tap output to for custom rendering')
   .alias('r', 'render')
 


### PR DESCRIPTION
Depends on https://github.com/juliangruber/electron-stream/pull/9
and https://github.com/juliangruber/browser-run/pull/85.

Will need to update `electron-stream` and `browser-run` dependencies here. 
