### PR TITLE
Document the `static` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ ok 1 true
 Increase this value if tests finish without all tests being run.
 * `port (Number)`: If you specify a port it will wait for you to open a browser
 on `http://localhost:<port>` and tests will be run there.
+* `static (String)`: Serve static files from this directory.
 * `browser (String)`: Browser to use. Defaults to `electron`. Available if installed:
   * `chrome`
   * `firefox`


### PR DESCRIPTION
`browser-run` has a feature to [serve static files](https://github.com/juliangruber/browser-run#runopts). This feature is really great, but suffers from being a bit hidden, when viewing `tape-run`'s API.

I think it should be documented in the readme, as well as the CLI. I added it to the readme in this PR.