### PR TITLE
Add detail to webpack integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ $ echo $?
 
 ## webpack
 
-To use with webpack, simply include this plugin:
-
-https://github.com/syarul/webpack-tape-run
+To use with [webpack](https://webpack.github.io/), set up a `webpack.test.config.js` to bundle your tape tests. Then, include [webpack-tape-run](https://github.com/syarul/webpack-tape-run) plugin in it. As a result, `$ webpack --config webpack.test.config.js` builds your tests with webpack, runs them in a headless browser, and outputs tap into console with correct exit code. Neat!
 
 ## API
 


### PR DESCRIPTION
The description needs more detail to really explain anything. This file change clarifies steps needed for webpack integration, yet with minimal bloat to keep README.md nice to browse and read.

Motivation: I believe there are people like me who use webpack instead of browserify and immediately want to integrate tape-run with webpack. With next to none details about the integration, it took me a long while to figure out everything needed. The first thing was that an additional `webpack.config.js` is needed to build the test suite. The second thing was that I can just `$ webpack --config ...` to run the tests, instead of something like `webpack | tape-run | tap-spec`. The third thing was that I do not need to add anything extra to the test code. These seem trivial afterwards but were hard to find out when everything was new.